### PR TITLE
Remove -mpaired from cflags

### DIFF
--- a/broadway.mk
+++ b/broadway.mk
@@ -4,7 +4,7 @@ endif
 
 PREFIX = $(DEVKITPPC)/bin/powerpc-eabi-
 
-CFLAGS = -mcpu=750 -mpaired -m32 -mhard-float -mno-eabi -mno-sdata
+CFLAGS = -mcpu=750 -m32 -mhard-float -mno-eabi -mno-sdata
 CFLAGS += -ffreestanding -ffunction-sections -fdata-sections
 CFLAGS += -Wall -Wextra -O2
 ASFLAGS =


### PR DESCRIPTION
This fixes compilation with GCC 10, which has been included with devkitPPC since r37.