### PR TITLE
Add #include <gcbool.h> to cache.h as latest devkitPPC requires it

### DIFF
--- a/channel/channelapp/stub/cache.h
+++ b/channel/channelapp/stub/cache.h
@@ -39,6 +39,7 @@ distribution.
 */ 
 
 #include <gctypes.h>
+#include <gcbool.h>
 
 #define LC_BASEPREFIX		0xe000
 #define LC_BASE				(LC_BASEPREFIX<<16)


### PR DESCRIPTION
To solve issue #19 